### PR TITLE
Set default next-visit date per menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const otherCheckbox = document.getElementById('other-checkbox');
     const otherPriceInput = document.getElementById('other-price');
 
+    function setDateByMenu() {
+      const today = new Date();
+      let minMonths = null;
+      checkboxes.forEach(cb => {
+        if (cb.checked && cb.dataset.months) {
+          const m = parseInt(cb.dataset.months, 10);
+          if (isNaN(m)) return;
+          if (minMonths === null || m < minMonths) {
+            minMonths = m;
+          }
+        }
+      });
+      const target = new Date(today);
+      if (minMonths !== null) {
+        target.setMonth(target.getMonth() + minMonths);
+      }
+      dateEl.value = target.toISOString().split('T')[0];
+    }
+
     function adjustToHalfHour(input) {
       const val = input.value;
       if (!val) return;
@@ -77,7 +96,10 @@ document.addEventListener('DOMContentLoaded', () => {
       qrcodeContainer.appendChild(img);
     }
   
-    checkboxes.forEach(cb => cb.addEventListener('change', calculateAmounts));
+    checkboxes.forEach(cb => cb.addEventListener('change', () => {
+      calculateAmounts();
+      setDateByMenu();
+    }));
     discountEl.addEventListener('input', calculateAmounts);
     // その他の金額入力時も再計算
     if (otherPriceInput) {
@@ -103,4 +125,6 @@ document.addEventListener('DOMContentLoaded', () => {
         generateQRCode();
       });
     }
+
+    setDateByMenu();
   });

--- a/index.html
+++ b/index.html
@@ -15,22 +15,22 @@
     <section class="appointment-form">
       <div class="menu-list">
         <label>
-          <input type="checkbox" class="menu-checkbox" data-price="3000">
+          <input type="checkbox" class="menu-checkbox" data-price="3000" data-months="1">
           <span class="menu-name">カット</span>
           <span class="price">¥3000</span>
         </label>
         <label>
-          <input type="checkbox" class="menu-checkbox" data-price="5000">
+          <input type="checkbox" class="menu-checkbox" data-price="5000" data-months="1">
           <span class="menu-name">カラー</span>
           <span class="price">¥5000</span>
         </label>
         <label>
-          <input type="checkbox" class="menu-checkbox" data-price="20000">
+          <input type="checkbox" class="menu-checkbox" data-price="20000" data-months="6">
           <span class="menu-name">髪質改善ストレート</span>
           <span class="price">¥20000</span>
         </label>
         <label>
-          <input type="checkbox" class="menu-checkbox" data-price="15000">
+          <input type="checkbox" class="menu-checkbox" data-price="15000" data-months="2">
           <span class="menu-name">髪質改善トリートメント</span>
           <span class="price">¥15000</span>
         </label>


### PR DESCRIPTION
## Summary
- add `data-months` to menu checkboxes
- auto-set visit date based on selected menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e6961b7548333a914d60b13cef6c3